### PR TITLE
Fix typos and clarity on pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -140,7 +140,7 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
               <li>Unlimited strategy calls</li>
               <li>Technical vendor coordination</li>
               <li>Support SLA: 1–2 hour response for P1 issues (Mon–Fri, 9am–5pm ET)</li>
-              <li><strong>Weekend Emergency Support included<strong></li>
+              <li><strong>Weekend Emergency Support included</strong></li>
             </ul>
           </div>
 

--- a/pricing.html
+++ b/pricing.html
@@ -45,7 +45,7 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
               <li>1 major Rails upgrade per year</li>
               <li>Security patching & dependency scanning</li>
               <li>Uptime & error monitoring</li>
-              <li>Quaterly system health report</li>
+              <li>Quarterly system health report</li>
               <li>Email support</li>
               <li>Support SLA: 48h Mon–Fri, 9am–5pm Eastern.</li>
             </ul>
@@ -67,7 +67,7 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
             <div class="plan-icon">🚀</div>
             <h2>Growth</h2>
             <div class="plan-price">$11,500<span>/month</span></div>
-            <p class="plan-description">For medium size apps or apps with custom infrastructure</p>
+            <p class="plan-description">For medium-size apps or apps with custom infrastructure</p>
           </div>
 
           <div class="plan-specs">
@@ -77,7 +77,7 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
             </div>
             <div class="spec-item">
               <span class="checkmark">✅</span>
-              <span>Custom devops</span>
+              <span>Custom DevOps</span>
             </div>
             <div class="spec-item">
               <span class="checkmark">✅</span>
@@ -117,13 +117,13 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
             <div class="plan-icon">🤝</div>
             <h2>Partner</h2>
             <div class="plan-price">Contact for pricing</div>
-            <p class="plan-description">For large apps or high-risk / high-complexity systems</p>
+            <p class="plan-description">For large apps, high-risk or high-complexity systems</p>
           </div>
 
           <div class="plan-specs">
             <div class="spec-item">
               <span class="checkmark">✅</span>
-              <span>Large apps — up to <strong>100,000 lines of code</strong></span>
+              <span>Large Apps — up to <strong>100,000 lines of code</strong></span>
             </div>
             <div class="spec-item">
               <span class="checkmark">✅</span>

--- a/pricing.html
+++ b/pricing.html
@@ -7,7 +7,7 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
 <main class="pricing-page">
   <section class="pricing-hero">
     <div class="container">
-      <h1>Rails Care Plan</h1>
+      <h1>Rails Care Plans</h1>
       <p class="hero-subtitle">Modern maintenance and support — upgrades, stability, and peace of mind.</p>
     </div>
   </section>

--- a/pricing.html
+++ b/pricing.html
@@ -7,8 +7,8 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
 <main class="pricing-page">
   <section class="pricing-hero">
     <div class="container">
-      <h1>Rails Fever Maintenance Plans</h1>
-      <p class="hero-subtitle">Modern maintenance and support for Ruby on Rails apps — upgrades, stability, and peace of mind.</p>
+      <h1>Rails Care Plan</h1>
+      <p class="hero-subtitle">Modern maintenance and support — upgrades, stability, and peace of mind.</p>
     </div>
   </section>
 
@@ -28,7 +28,7 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
           <div class="plan-specs">
             <div class="spec-item">
               <span class="checkmark">✅</span>
-              <span>Up to <strong>20,000 lines of code</strong></span>
+              <span>Small Apps — up to <strong>20,000 lines of code</strong></span>
             </div>
             <div class="spec-item">
               <span class="checkmark">✅</span>
@@ -39,21 +39,15 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
           <div class="plan-features">
             <h3>Includes:</h3>
             <ul>
+              <li>Bug Fixes</li>
+              <li>Feature work: Priced per project</li>
               <li>Monthly gem & patch-level updates</li>
               <li>1 major Rails upgrade per year</li>
               <li>Security patching & dependency scanning</li>
               <li>Uptime & error monitoring</li>
-              <li>Monthly system health report</li>
+              <li>Quaterly system health report</li>
               <li>Email support</li>
               <li>Support SLA: 48h Mon–Fri, 9am–5pm Eastern.</li>
-              <li>No weekend coverage.</li>
-            </ul>
-
-            <h3>Not Included:</h3>
-            <ul class="not-included">
-              <li>Custom DevOps</li>
-              <li>Feature work</li>
-              <li>Emergency support</li>
             </ul>
           </div>
 
@@ -73,27 +67,28 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
             <div class="plan-icon">🚀</div>
             <h2>Growth</h2>
             <div class="plan-price">$11,500<span>/month</span></div>
-            <p class="plan-description">For apps with custom infrastructure</p>
+            <p class="plan-description">For medium size apps or apps with custom infrastructure</p>
           </div>
 
           <div class="plan-specs">
             <div class="spec-item">
               <span class="checkmark">✅</span>
-              <span>Up to <strong>60,000 lines of code</strong></span>
+              <span>Medium Apps — up to <strong>60,000 lines of code</strong></span>
             </div>
             <div class="spec-item">
               <span class="checkmark">✅</span>
-              <span>Deployed with <strong>Ansible, Capistrano</strong>, or CI/CD scripts</span>
+              <span>Custom devops</span>
             </div>
             <div class="spec-item">
               <span class="checkmark">✅</span>
-              <span>Hosted on <strong>AWS, DigitalOcean, GCP</strong>, or similar</span>
+              <span>Hosted on <strong>AWS, Linode, GCP</strong>, or similar VPS</span>
             </div>
           </div>
 
           <div class="plan-features">
             <h3>Includes everything in Foundation, plus:</h3>
             <ul>
+              <li>Feature work: Includes enhancements to existing features</li>
               <li>Upgrade roadmap & milestone tracking</li>
               <li>Deployment pipeline support</li>
               <li>Infrastructure config troubleshooting</li>
@@ -122,13 +117,13 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
             <div class="plan-icon">🤝</div>
             <h2>Partner</h2>
             <div class="plan-price">Contact for pricing</div>
-            <p class="plan-description">For high-risk or high-complexity systems</p>
+            <p class="plan-description">For large apps or high-risk / high-complexity systems</p>
           </div>
 
           <div class="plan-specs">
             <div class="spec-item">
               <span class="checkmark">✅</span>
-              <span>Up to <strong>100,000 lines of code</strong></span>
+              <span>Large apps — up to <strong>100,000 lines of code</strong></span>
             </div>
             <div class="spec-item">
               <span class="checkmark">✅</span>


### PR DESCRIPTION
## Summary

Copy review of the recent pricing page update (`8cf53c4`). Fixes one typo and a few consistency/clarity nits:

- **Typo:** "Quaterly" → "Quarterly" (system health report)
- **Capitalization:** "Custom devops" → "Custom DevOps" (matches brand usage)
- **Consistency:** "Large apps" → "Large Apps" (to match the "Small Apps" / "Medium Apps" spec labels)
- **Clarity:** "medium size apps" → "medium-size apps" (compound adjective)
- **Clarity:** Partner description reworded to "For large apps, high-risk or high-complexity systems"

No structural or pricing changes — copy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the pricing page copy for all plan tiers to better reflect current offerings and app sizes.
  * Clarified plan descriptions, including small, medium, and large app coverage.
  * Added more explicit inclusions around bug fixes, feature work, and quarterly health reporting.

* **Bug Fixes**
  * Refined the pricing content and plan wording for clearer presentation and easier comparison across tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->