### PR TITLE
Make /pricing/ a multi-service pricing hub (Option D)

### DIFF
--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -26,13 +26,14 @@ emergency:
         - "Severe performance collapse"
     - id: critical
       name: "Critical Incident"
-      price: "$12,000"
-      description: "Catastrophic failures requiring full recovery."
+      price: "Starting at $12,000"
+      description: "Catastrophic failures requiring full recovery — scoped after triage."
       examples:
         - "App offline / unusable"
         - "Corrupted data"
-        - "Security breach"
+        - "Suspected security breach"
   surcharge_note: "Nights and weekend emergencies include a surcharge of $1,000 - $2,000 (tier based) for immediate response."
+  breach_note: "Confirmed security breaches are scoped and quoted separately."
 
 # Quote-based / project services. Shown on /pricing/ under
 # "Project-Based Services", each linking to its service page.

--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -1,0 +1,64 @@
+# Single source of truth for pricing shown across the site.
+# Rendered on /pricing/ (the hub) and on individual service pages.
+# Change a price here and every page that displays it updates.
+
+# Per-incident emergency response (Rails Support Desk).
+# Shown as detailed cards on /services/rails_support_desk/ and as a
+# summary on /pricing/. The Support Desk page is the canonical detail page.
+emergency:
+  intro: "Flat-rate emergency response — no hourly surprises."
+  tiers:
+    - id: minor
+      name: "Minor Incident"
+      price: "$3,000"
+      description: "Clear root cause, resolved same day."
+      examples:
+        - "Expired SSL"
+        - "Background jobs stuck"
+        - "Third-party API key expired"
+    - id: major
+      name: "Major Incident"
+      price: "$6,000"
+      description: "Multi-layer failures, up to 2 days to stabilize."
+      examples:
+        - "Database issues"
+        - "Payments failing"
+        - "Severe performance collapse"
+    - id: critical
+      name: "Critical Incident"
+      price: "$12,000"
+      description: "Catastrophic failures requiring full recovery."
+      examples:
+        - "App offline / unusable"
+        - "Corrupted data"
+        - "Security breach"
+  surcharge_note: "Nights and weekend emergencies include a surcharge of $1,000 - $2,000 (tier based) for immediate response."
+
+# Quote-based / project services. Shown on /pricing/ under
+# "Project-Based Services", each linking to its service page.
+project_services:
+  - name: "Rails Upgrade Express"
+    icon: "⬆️"
+    url: "/services/rails_upgrade_express/"
+    pricing_model: "Quoted per project"
+    description: "Safe, staged Ruby and Rails version upgrades with test fixes and compatibility work."
+  - name: "Rails Tech Audit"
+    icon: "🔍"
+    url: "/services/rails_tech_audit/"
+    pricing_model: "Fixed-scope audit"
+    description: "A deep technical review of your app with a prioritized risk and improvement roadmap."
+  - name: "Rails Rescue Kit"
+    icon: "🛟"
+    url: "/services/rails_rescue_kit/"
+    pricing_model: "Flat project rate"
+    description: "Diagnose and stabilize a broken or failing legacy Rails app, fast."
+  - name: "Feature Development"
+    icon: "✨"
+    url: "/services/rails_feature_development/"
+    pricing_model: "Monthly engagement or scoped build"
+    description: "Senior-led feature delivery inside your existing Rails app — no hiring required."
+  - name: "Fractional CTO"
+    icon: "🧭"
+    url: "/services/fractional_cto/"
+    pricing_model: "Monthly retainer"
+    description: "Technical leadership — architecture, hiring, and strategy — without a full-time hire."

--- a/_sass/_pricing.scss
+++ b/_sass/_pricing.scss
@@ -382,6 +382,176 @@
     }
   }
 
+  // Shared section heading for the hub's pricing sections
+  .section-heading {
+    text-align: center;
+    max-width: 800px;
+    margin: 0 auto 3rem;
+
+    h2 {
+      font-size: 2.2rem;
+      color: #333;
+      margin-bottom: 1rem;
+    }
+
+    .section-intro {
+      font-size: 1.2rem;
+      color: #666;
+    }
+  }
+
+  // Emergency Support — compact summary cards (detail lives on Support Desk page)
+  .emergency-pricing {
+    padding: 4rem 0;
+    background: white;
+
+    .emergency-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 2rem;
+
+      @media (max-width: 1024px) {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+      }
+    }
+
+    .emergency-card {
+      background: #f8f9fa;
+      border-radius: 12px;
+      padding: 2rem;
+      text-align: center;
+      border-top: 4px solid #f39c12;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+      &:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+      }
+
+      &.major { border-top-color: #e67e22; }
+      &.critical { border-top-color: #D61A32; }
+
+      h3 {
+        font-size: 1.4rem;
+        color: #333;
+        margin-bottom: 0.75rem;
+      }
+
+      .price {
+        font-size: 2.5rem;
+        font-weight: 700;
+        color: #D61A32;
+        margin-bottom: 0.75rem;
+      }
+
+      .price-description {
+        color: #666;
+        margin: 0;
+        line-height: 1.5;
+      }
+    }
+
+    .pricing-note {
+      text-align: center;
+      color: #666;
+      margin-top: 2rem;
+      font-size: 0.95rem;
+    }
+
+    .section-cta {
+      text-align: center;
+      margin-top: 2rem;
+    }
+  }
+
+  // Project-based services — linked cards to each service page
+  .project-services {
+    padding: 4rem 0;
+    background: #f8f9fa;
+
+    .project-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 2rem;
+
+      @media (max-width: 1024px) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      @media (max-width: 768px) {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+      }
+    }
+
+    .project-card {
+      display: block;
+      background: white;
+      border-radius: 12px;
+      padding: 2rem;
+      text-decoration: none;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+      &:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+
+        .project-link {
+          text-decoration: underline;
+        }
+      }
+
+      .project-icon {
+        font-size: 2.5rem;
+        margin-bottom: 1rem;
+      }
+
+      h3 {
+        font-size: 1.3rem;
+        color: #333;
+        margin-bottom: 0.5rem;
+      }
+
+      .project-model {
+        font-weight: 600;
+        color: #667eea;
+        margin-bottom: 0.75rem;
+      }
+
+      .project-desc {
+        color: #555;
+        line-height: 1.5;
+        margin-bottom: 1rem;
+      }
+
+      .project-link {
+        font-weight: 600;
+        color: #D61A32;
+      }
+    }
+  }
+
+  // Outline button used for cross-links between pricing sections/pages
+  .btn-outline {
+    display: inline-block;
+    padding: 0.85rem 1.75rem;
+    border: 2px solid #D61A32;
+    border-radius: 8px;
+    color: #D61A32;
+    background: transparent;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s ease, color 0.2s ease;
+
+    &:hover {
+      background: #D61A32;
+      color: white;
+    }
+  }
+
   .pricing-faq {
     padding: 3rem 0;
     background: white;

--- a/pricing.html
+++ b/pricing.html
@@ -179,6 +179,9 @@ description: Transparent pricing for Ruby on Rails services — monthly care pla
       </div>
 
       <p class="pricing-note"><strong>Note:</strong> {{ site.data.pricing.emergency.surcharge_note }}</p>
+      {% if site.data.pricing.emergency.breach_note %}
+      <p class="pricing-note">{{ site.data.pricing.emergency.breach_note }}</p>
+      {% endif %}
 
       <div class="section-cta">
         <a href="/services/rails_support_desk/" class="btn btn-outline">See full emergency support details →</a>

--- a/pricing.html
+++ b/pricing.html
@@ -1,19 +1,23 @@
 ---
 layout: default
-title: Pricing Plans
-description: Modern maintenance and support for Ruby on Rails apps — upgrades, stability, and peace of mind. Choose the plan that fits your app's needs.
+title: Pricing
+description: Transparent pricing for Ruby on Rails services — monthly care plans, flat-rate emergency support, and project-based upgrades, audits, rescues, and feature work.
 ---
 
 <main class="pricing-page">
   <section class="pricing-hero">
     <div class="container">
-      <h1>Rails Care Plans</h1>
-      <p class="hero-subtitle">Modern maintenance and support — upgrades, stability, and peace of mind.</p>
+      <h1>Simple, Transparent Pricing</h1>
+      <p class="hero-subtitle">Monthly care plans, flat-rate emergency help, and project-based work — pick the engagement that fits your Rails app.</p>
     </div>
   </section>
 
   <section class="pricing-plans">
     <div class="container">
+      <div class="section-heading">
+        <h2>Rails Care Plans</h2>
+        <p class="section-intro">Ongoing maintenance and support on a predictable monthly retainer, priced by your app's size and complexity.</p>
+      </div>
       <div class="plans-grid">
 
         <!-- Foundation Plan -->
@@ -153,6 +157,52 @@ description: Modern maintenance and support for Ruby on Rails apps — upgrades,
           </div>
         </div>
 
+      </div>
+    </div>
+  </section>
+
+  <section class="emergency-pricing">
+    <div class="container">
+      <div class="section-heading">
+        <h2>Emergency Support</h2>
+        <p class="section-intro">{{ site.data.pricing.emergency.intro }} One-off incident response when your app is down — no retainer required.</p>
+      </div>
+
+      <div class="emergency-grid">
+        {% for tier in site.data.pricing.emergency.tiers %}
+        <div class="emergency-card {{ tier.id }}">
+          <h3>{{ tier.name }}</h3>
+          <div class="price">{{ tier.price }}</div>
+          <p class="price-description">{{ tier.description }}</p>
+        </div>
+        {% endfor %}
+      </div>
+
+      <p class="pricing-note"><strong>Note:</strong> {{ site.data.pricing.emergency.surcharge_note }}</p>
+
+      <div class="section-cta">
+        <a href="/services/rails_support_desk/" class="btn btn-outline">See full emergency support details →</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="project-services">
+    <div class="container">
+      <div class="section-heading">
+        <h2>Project-Based Services</h2>
+        <p class="section-intro">One-time upgrades, audits, rescues, and feature work are scoped and quoted per project. Book a consultation for a tailored quote.</p>
+      </div>
+
+      <div class="project-grid">
+        {% for svc in site.data.pricing.project_services %}
+        <a class="project-card" href="{{ svc.url }}">
+          <div class="project-icon">{{ svc.icon }}</div>
+          <h3>{{ svc.name }}</h3>
+          <p class="project-model">{{ svc.pricing_model }}</p>
+          <p class="project-desc">{{ svc.description }}</p>
+          <span class="project-link">Learn more →</span>
+        </a>
+        {% endfor %}
       </div>
     </div>
   </section>

--- a/services/fractional_cto.html
+++ b/services/fractional_cto.html
@@ -45,5 +45,6 @@ description: Technical leadership for your SaaS company. Our Fractional CTO serv
   <section id="contact" class="contact">
     <h2>Strategic Leadership. Without Full-Time Cost.</h2>
     <a href="{{ site.schedule_meeting_link }}" target="_blank">Request Your CTO Consultation</a>
+    <a href="/pricing/">See Pricing</a>
   </section>
 </div>

--- a/services/rails_rescue_kit.html
+++ b/services/rails_rescue_kit.html
@@ -68,5 +68,6 @@ description: Stuck with a broken Rails app? Rails Rescue Kit helps diagnose and 
   <section id="contact" class="contact">
     <h2>Ready to reclaim your SaaS momentum?</h2>
     <a href="{{ site.schedule_meeting_link }}" target="_blank">Schedule Your Rescue Consultation</a>
+    <a href="/pricing/">See Pricing</a>
   </section>
 </div>

--- a/services/rails_support_desk.html
+++ b/services/rails_support_desk.html
@@ -44,48 +44,25 @@ description: On-demand support for your Rails app. Rails Support Desk handles bu
   <section class="pricing-section">
     <h2>Rails Emergency Help — Flat Rates — Avoid Surprises</h2>
     <div class="pricing-grid">
-      <div class="pricing-card minor">
-        <h3>Minor Incident</h3>
-        <div class="price">$3,000</div>
-        <p class="price-description">Clear root cause, resolved same day.</p>
+      {% comment %} Prices are the single source of truth in _data/pricing.yml {% endcomment %}
+      {% for tier in site.data.pricing.emergency.tiers %}
+      <div class="pricing-card {{ tier.id }}">
+        <h3>{{ tier.name }}</h3>
+        <div class="price">{{ tier.price }}</div>
+        <p class="price-description">{{ tier.description }}</p>
         <div class="pricing-examples">
           <p><strong>Examples:</strong></p>
           <ul>
-            <li>Expired SSL</li>
-            <li>Background jobs stuck</li>
-            <li>Third-party API key expired</li>
+            {% for example in tier.examples %}
+            <li>{{ example }}</li>
+            {% endfor %}
           </ul>
         </div>
       </div>
-      <div class="pricing-card major">
-        <h3>Major Incident</h3>
-        <div class="price">$6,000</div>
-        <p class="price-description">Multi-layer failures, up to 2 days to stabilize.</p>
-        <div class="pricing-examples">
-          <p><strong>Examples:</strong></p>
-          <ul>
-            <li>Database issues</li>
-            <li>Payments failing</li>
-            <li>Severe performance collapse</li>
-          </ul>
-        </div>
-      </div>
-      <div class="pricing-card critical">
-        <h3>Critical Incident</h3>
-        <div class="price">$12,000</div>
-        <p class="price-description">Catastrophic failures requiring full recovery.</p>
-        <div class="pricing-examples">
-          <p><strong>Examples:</strong></p>
-          <ul>
-            <li>App offline / unusable</li>
-            <li>Corrupted data</li>
-            <li>Security breach</li>
-          </ul>
-        </div>
-      </div>
+      {% endfor %}
     </div>
     <p class="pricing-note">
-      <strong>Note:</strong> Nights and weekend emergencies include a surcharge of $1,000 - $2,000 (tier based) for immediate response.
+      <strong>Note:</strong> {{ site.data.pricing.emergency.surcharge_note }}
     </p>
   </section>
 

--- a/services/rails_support_desk.html
+++ b/services/rails_support_desk.html
@@ -64,6 +64,9 @@ description: On-demand support for your Rails app. Rails Support Desk handles bu
     <p class="pricing-note">
       <strong>Note:</strong> {{ site.data.pricing.emergency.surcharge_note }}
     </p>
+    {% if site.data.pricing.emergency.breach_note %}
+    <p class="pricing-note">{{ site.data.pricing.emergency.breach_note }}</p>
+    {% endif %}
   </section>
 
   <!-- How It Works Section -->
@@ -121,7 +124,7 @@ description: On-demand support for your Rails app. Rails Support Desk handles bu
           <span class="faq-toggle">+</span>
         </button>
         <div class="faq-answer">
-          <p>After a quick intake call, we'll tell you whether it's Minor ($3K), Major ($6K), or Critical ($12K). Most emergencies fall into the Major tier. You'll know the cost upfront — no surprises.</p>
+          <p>After a quick intake call, we'll tell you whether it's Minor ($3K), Major ($6K), or Critical (from $12K, scoped after triage). Most emergencies fall into the Major tier. Confirmed security breaches are scoped and quoted separately. You'll know the cost upfront — no surprises.</p>
         </div>
       </div>
       <div class="faq-item">

--- a/services/rails_tech_audit.html
+++ b/services/rails_tech_audit.html
@@ -47,5 +47,6 @@ description: Get a deep technical audit of your Rails app. Identify risks, bottl
   <section id="contact" class="contact">
     <h2>Get a Clear Roadmap. Build with Confidence.</h2>
     <a href="{{ site.schedule_meeting_link }}" target="_blank">Schedule Your Tech Audit</a>
+    <a href="/pricing/">See Pricing</a>
   </section>
 </div>

--- a/services/rails_upgrade_express.html
+++ b/services/rails_upgrade_express.html
@@ -57,5 +57,6 @@ description: Upgrade your Rails app safely and efficiently. Rails Upgrade Expres
     <h2>Ready to Move Fast — Without Breaking Things?</h2>
     <p>After your upgrade, protect your investment with ongoing <a href="/services/rails_care_plan">Rails Care Plan maintenance</a> to stay current.</p>
     <a href="{{ site.schedule_meeting_link }}" target="_blank">Schedule Your Upgrade Consultation</a>
+    <a href="/pricing/">See Pricing</a>
   </section>
 </div>


### PR DESCRIPTION
## Summary

Resolves the information-architecture mismatch where the top-level **Pricing** nav item only priced one of seven services (the Rails Care Plan). `/pricing/` is now an honest, site-wide pricing hub. The `/pricing/` URL is unchanged, so all existing internal links (nav + 20+ blog posts) and SEO equity are preserved — no redirect needed.

## Changes

- **`_data/pricing.yml` (new)** — single source of truth for the emergency incident tiers (+ surcharge note) and the five project-based services.
- **`pricing.html`** — reframed hero to site-wide; kept the Care Plan tiers; added an **Emergency Support** summary-card section (rendered from data, links to the Support Desk detail page) and a **Project-Based Services** section (Upgrade Express, Tech Audit, Rescue Kit, Feature Dev, Fractional CTO).
- **`services/rails_support_desk.html`** — its incident pricing cards now render from `_data/pricing.yml`, so the hub summary and the detail page can't drift. (Support Desk pricing stays — it's a distinct per-incident model and the canonical detail page.)
- **Four service pages** (rescue kit, tech audit, upgrade express, fractional CTO) — added a "See Pricing" CTA linking to `/pricing/`.
- **`_sass/_pricing.scss`** — styles for the new emergency/project card grids and section headings, reusing existing card patterns.

## Decision: Care Plan tiers kept inline

The Care Plan tier cards live only on `/pricing/` (no duplication to prevent), contain rich markup/marketing copy, and YAML build-fragility/complexity would add risk for no payoff. They stay as inline HTML. (Only worth migrating if the tiers later appear in a second place, e.g. a homepage teaser.)

## Verification

- `bundle exec jekyll build` clean; all four hub sections render.
- **Single source of truth proven:** changing a price in `_data/pricing.yml` updated both the hub and the Support Desk page; reverted cleanly.
- All five project services link to their pages; all four service pages now link to `/pricing/`; `/pricing/` URL and nav unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic Emergency Support pricing with tiered cards, surcharge and breach scoping notes, plus a dedicated CTA.
  * Added a Project-Based Services section with linked service cards and pricing model details.
  * Added “See Pricing” links to multiple service pages to improve navigation.

* **Bug Fixes**
  * Converted Rails Emergency Help pricing and FAQ tier guidance to be rendered from shared pricing content for consistent display.

* **Style**
  * Refreshed pricing page layout, headings, and card/button styling for a cleaner, more responsive presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->