### PR TITLE
Add flat $3,000 Rails Tech Audit with 30-day credit

### DIFF
--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -53,6 +53,7 @@ project_services:
     url: "/services/rails_tech_audit/"
     pricing_model: "$3,000 flat"
     turnaround: "Delivered in ~1 week"
+    scope_note: "Flat rate covers a single Rails application up to ~60,000 lines of code. Larger or multi-app systems: contact for a tailored audit."
     credit: "The full $3,000 is credited toward a Care Plan or project engagement if you start within 30 days."
     description: "A deep technical review of your app with a prioritized risk and improvement roadmap — including a team process review to surface bottlenecks."
   - id: rescue

--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -38,27 +38,37 @@ emergency:
 # Quote-based / project services. Shown on /pricing/ under
 # "Project-Based Services", each linking to its service page.
 project_services:
-  - name: "Rails Upgrade Express"
+  - id: upgrade
+    name: "Rails Upgrade Express"
     icon: "⬆️"
     url: "/services/rails_upgrade_express/"
     pricing_model: "Quoted per project"
     description: "Safe, staged Ruby and Rails version upgrades with test fixes and compatibility work."
-  - name: "Rails Tech Audit"
+  # The Rails Tech Audit is a fixed-price offer. This entry is the single source
+  # of truth for its price, turnaround, and credit terms — rendered on both
+  # /pricing/ and /services/rails_tech_audit/ (looked up there by id).
+  - id: audit
+    name: "Rails Tech Audit"
     icon: "🔍"
     url: "/services/rails_tech_audit/"
-    pricing_model: "Fixed-scope audit"
-    description: "A deep technical review of your app with a prioritized risk and improvement roadmap."
-  - name: "Rails Rescue Kit"
+    pricing_model: "$3,000 flat"
+    turnaround: "Delivered in ~1 week"
+    credit: "The full $3,000 is credited toward a Care Plan or project engagement if you start within 30 days."
+    description: "A deep technical review of your app with a prioritized risk and improvement roadmap — including a team process review to surface bottlenecks."
+  - id: rescue
+    name: "Rails Rescue Kit"
     icon: "🛟"
     url: "/services/rails_rescue_kit/"
     pricing_model: "Flat project rate"
     description: "Diagnose and stabilize a broken or failing legacy Rails app, fast."
-  - name: "Feature Development"
+  - id: feature
+    name: "Feature Development"
     icon: "✨"
     url: "/services/rails_feature_development/"
     pricing_model: "Monthly engagement or scoped build"
     description: "Senior-led feature delivery inside your existing Rails app — no hiring required."
-  - name: "Fractional CTO"
+  - id: cto
+    name: "Fractional CTO"
     icon: "🧭"
     url: "/services/fractional_cto/"
     pricing_model: "Monthly retainer"

--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -53,7 +53,7 @@ project_services:
     url: "/services/rails_tech_audit/"
     pricing_model: "$3,000 flat"
     turnaround: "Delivered in ~1 week"
-    scope_note: "Flat rate covers a single Rails application up to ~60,000 lines of code. Larger or multi-app systems: contact for a tailored audit."
+    scope_note: "Fixed price for a typical single-app SaaS. Running something larger or multi-app? We'll tailor a quote — just ask."
     credit: "The full $3,000 is credited toward a Care Plan or project engagement if you start within 30 days."
     description: "A deep technical review of your app with a prioritized risk and improvement roadmap — including a team process review to surface bottlenecks."
   - id: rescue

--- a/_sass/_pricing.scss
+++ b/_sass/_pricing.scss
@@ -527,6 +527,16 @@
         margin-bottom: 1rem;
       }
 
+      .project-credit {
+        background: #fff8ec;
+        border-radius: 8px;
+        padding: 0.65rem 0.85rem;
+        font-size: 0.9rem;
+        color: #7a4a1d;
+        line-height: 1.4;
+        margin-bottom: 1rem;
+      }
+
       .project-link {
         font-weight: 600;
         color: #D61A32;

--- a/_sass/_pricing.scss
+++ b/_sass/_pricing.scss
@@ -521,6 +521,13 @@
         margin-bottom: 0.75rem;
       }
 
+      .project-scope {
+        font-size: 0.85rem;
+        color: #888;
+        line-height: 1.4;
+        margin-bottom: 0.75rem;
+      }
+
       .project-desc {
         color: #555;
         line-height: 1.5;

--- a/_sass/services/_tech_audit.scss
+++ b/_sass/services/_tech_audit.scss
@@ -1,3 +1,39 @@
 .tech-audit-service {
   // Uses shared .problem-card, .audit-section, .audit-list, .audit-item from _components.scss
+
+  .audit-pricing {
+    text-align: center;
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 60px 20px 20px;
+
+    h2 {
+      margin-bottom: 1rem;
+    }
+
+    .audit-price {
+      font-size: 3rem;
+      font-weight: 700;
+      color: #D61A32;
+      line-height: 1.1;
+    }
+
+    .audit-turnaround {
+      color: #4F4F4F;
+      font-size: 1.1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .audit-credit {
+      background: #f8f9fa;
+      border-left: 4px solid #C3703D;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      color: #333;
+      line-height: 1.5;
+      max-width: 520px;
+      margin: 0 auto 2rem;
+      text-align: left;
+    }
+  }
 }

--- a/_sass/services/_tech_audit.scss
+++ b/_sass/services/_tech_audit.scss
@@ -21,7 +21,15 @@
     .audit-turnaround {
       color: #4F4F4F;
       font-size: 1.1rem;
-      margin-bottom: 1.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .audit-scope {
+      color: #777;
+      font-size: 0.9rem;
+      line-height: 1.5;
+      max-width: 480px;
+      margin: 0 auto 1.5rem;
     }
 
     .audit-credit {

--- a/pricing.html
+++ b/pricing.html
@@ -203,6 +203,7 @@ description: Transparent pricing for Ruby on Rails services — monthly care pla
           <h3>{{ svc.name }}</h3>
           <p class="project-model">{{ svc.pricing_model }}</p>
           <p class="project-desc">{{ svc.description }}</p>
+          {% if svc.credit %}<p class="project-credit">💡 {{ svc.credit }}</p>{% endif %}
           <span class="project-link">Learn more →</span>
         </a>
         {% endfor %}

--- a/pricing.html
+++ b/pricing.html
@@ -202,6 +202,7 @@ description: Transparent pricing for Ruby on Rails services — monthly care pla
           <div class="project-icon">{{ svc.icon }}</div>
           <h3>{{ svc.name }}</h3>
           <p class="project-model">{{ svc.pricing_model }}</p>
+          {% if svc.scope_note %}<p class="project-scope">{{ svc.scope_note }}</p>{% endif %}
           <p class="project-desc">{{ svc.description }}</p>
           {% if svc.credit %}<p class="project-credit">💡 {{ svc.credit }}</p>{% endif %}
           <span class="project-link">Learn more →</span>

--- a/services/rails_tech_audit.html
+++ b/services/rails_tech_audit.html
@@ -41,6 +41,7 @@ description: Get a deep technical audit of your Rails app. Identify risks, bottl
       <div class="audit-item">CI/CD Pipeline Analysis</div>
       <div class="audit-item">Testing Coverage & Gaps Evaluation</div>
       <div class="audit-item">Disaster Recovery & Backup Review</div>
+      <div class="audit-item">Team Process Review to Surface Bottlenecks</div>
     </div>
   </section>
 

--- a/services/rails_tech_audit.html
+++ b/services/rails_tech_audit.html
@@ -44,6 +44,15 @@ description: Get a deep technical audit of your Rails app. Identify risks, bottl
     </div>
   </section>
 
+  {% assign audit = site.data.pricing.project_services | where: "id", "audit" | first %}
+  <section class="audit-pricing">
+    <h2>Simple, Fixed Pricing</h2>
+    <div class="audit-price">{{ audit.pricing_model }}</div>
+    <p class="audit-turnaround">{{ audit.turnaround }}</p>
+    <p class="audit-credit">💡 {{ audit.credit }}</p>
+    <a href="{{ site.schedule_meeting_link }}" target="_blank" class="cta-button">Book Your Audit</a>
+  </section>
+
   <section id="contact" class="contact">
     <h2>Get a Clear Roadmap. Build with Confidence.</h2>
     <a href="{{ site.schedule_meeting_link }}" target="_blank">Schedule Your Tech Audit</a>

--- a/services/rails_tech_audit.html
+++ b/services/rails_tech_audit.html
@@ -50,6 +50,7 @@ description: Get a deep technical audit of your Rails app. Identify risks, bottl
     <h2>Simple, Fixed Pricing</h2>
     <div class="audit-price">{{ audit.pricing_model }}</div>
     <p class="audit-turnaround">{{ audit.turnaround }}</p>
+    <p class="audit-scope">{{ audit.scope_note }}</p>
     <p class="audit-credit">💡 {{ audit.credit }}</p>
     <a href="{{ site.schedule_meeting_link }}" target="_blank" class="cta-button">Book Your Audit</a>
   </section>


### PR DESCRIPTION
## Summary

Turns the Rails Tech Audit into a low-friction, fixed-price entry point designed to convert into retainer/project work — priced well under the typical ~$12k agency audit (2 devs, 1–2 weeks) by leveraging a senior-solo model.

- **$3,000 flat**, delivered in ~1 week, including a team process review to surface bottlenecks.
- **30-day credit:** the full $3,000 is credited toward a Care Plan or project engagement if they start within 30 days — the "easy yes" closer.

## Changes

- **`_data/pricing.yml`** — the Tech Audit `project_services` entry is now the single source of truth for its price, turnaround, and credit terms. Added `id` fields to project services so the service page can look the audit up.
- **`services/rails_tech_audit.html`** — new "Simple, Fixed Pricing" section rendered from the data (price + turnaround + credit) with a booking CTA.
- **`pricing.html`** — the hub's audit card now surfaces the 30-day credit line.
- **SCSS** — styling for the audit pricing block (`_tech_audit.scss`) and the hub credit note (`_pricing.scss`).

## Verification

- `bundle exec jekyll build` clean; the fixed-price section and credit render on both the Tech Audit page and the `/pricing/` hub.
- **Single source of truth proven:** changing the price in `_data/pricing.yml` updated both surfaces; reverted cleanly.
- Other project-service cards are unaffected (credit line shows only on the audit card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the pricing and service cards to show clearer project details, including turnaround time, scope notes, and credit terms.
  * Added a dedicated pricing section to the Rails Tech Audit page with an easy booking call to action.
  * Expanded the audit contents to include a team process review item.
* **Style**
  * Refreshed pricing-related layouts and callout styling for better readability and emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->